### PR TITLE
Allow relative ~~fileName~~ filePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ document.body.appendChild(container);
 | `svgDomId` | `string` | `svg-sprite` | ID attribute for the root SVG sprite element in the DOM |
 | `inject` | `'body-last' \| 'body-first'` | `undefined` | Controls where the sprite is injected in the HTML. `body-first` injects at start of body, `body-last` at the end |
 | `svgoConfig` | `object` | See SVGO section | Configuration for SVGO optimization. Override default settings for SVG optimization |
-| `fileName` | `string` | `undefined` | If provided, saves the sprite to a file instead of injecting it. Example: `sprite.svg` |
+| `filePath` | `string` | `undefined` | If provided, saves the sprite to a file instead of injecting it. Example: `assets/sprite.svg` |
 | `verbose` | `boolean` | `true` | Enable/disable detailed logging output during plugin operation |
 
 ### Default SVGO Configuration
@@ -136,7 +136,7 @@ svgSpritePlugin({
 svgSpritePlugin({
   iconDirs: ['src/icons'],
   symbolId: 'icon-[name]',
-  fileName: 'sprite.svg'
+  filePath: 'assets/sprite.svg'
 })
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ interface SvgSpritePluginOptions {
   svgDomId?: string;
   inject?: 'body-last' | 'body-first';
   svgoConfig?: object;
-  fileName?: string;
+  filePath?: string;
   verbose?: boolean;
 }
 
@@ -59,7 +59,7 @@ const svgSpritePlugin = (options: SvgSpritePluginOptions): Plugin => {
       ],
     },
     inject,
-    fileName,
+    filePath,
     verbose = true,
   } = options;
 
@@ -177,10 +177,10 @@ const svgSpritePlugin = (options: SvgSpritePluginOptions): Plugin => {
 
   const writeSpriteToFile = (
     publicDir: string,
-    fileName: string,
+    filePath: string,
     spriteContent: string,
   ) => {
-    const fullPath = path.join(publicDir, fileName);
+    const fullPath = path.join(publicDir, filePath);
     const finalSpriteContent = `${spriteContent.trim()}\n`;
 
     try {
@@ -247,9 +247,9 @@ const svgSpritePlugin = (options: SvgSpritePluginOptions): Plugin => {
             await generateSvgSprite();
             log.info('💫 SVG changed');
 
-            if (fileName) {
+            if (filePath) {
               const publicDir = config.build.outDir;
-              writeSpriteToFile(publicDir, fileName, spriteContent);
+              writeSpriteToFile(publicDir, filePath, spriteContent);
             }
 
             // Touch entry file to trigger rebuild
@@ -365,9 +365,9 @@ const svgSpritePlugin = (options: SvgSpritePluginOptions): Plugin => {
 
     generateBundle(this, options) {
       // Write sprite file during bundle generation
-      if (fileName && !hasGeneratedSprite) {
+      if (filePath && !hasGeneratedSprite) {
         const publicDir = options.dir || 'public';
-        writeSpriteToFile(publicDir, fileName, spriteContent);
+        writeSpriteToFile(publicDir, filePath, spriteContent);
         // Mark that we've generated the sprite to prevent multiple writes
         hasGeneratedSprite = true;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,9 +192,10 @@ const svgSpritePlugin = (options: SvgSpritePluginOptions): Plugin => {
         }
       }
 
-      fs.mkdirSync(publicDir, { recursive: true });
+      const dir = path.dirname(fullPath)
+      fs.mkdirSync(dir, { recursive: true });
       fs.writeFileSync(fullPath, finalSpriteContent);
-      log.info(`💫 SVG sprite saved in ${publicDir}`);
+      log.info(`💫 SVG sprite saved in ${dir}`);
     } catch (error) {
       log.error(`Error writing sprite file: ${fullPath}`, error);
     }


### PR DESCRIPTION
These little changes allow `filePath` (previously `fileName`) to be relative.
Done in two commits, the latter is for renaming the variable.