### PR TITLE
feat: don't output root SVG ID attribute when omitting "svgDomId" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ document.body.appendChild(container);
 |--------|------|---------|-------------|
 | `iconDirs` | `string[]` | Required | Directories containing SVG files to be processed into sprites |
 | `symbolId` | `string` | `[dir]-[name]` | Format for symbol IDs. Uses placeholders: `[dir]` (directory name) and `[name]` (file name without extension). Example: `[dir]-[name]` for `icons/home.svg` becomes `icons-home` |
-| `svgDomId` | `string` | `svg-sprite` | ID attribute for the root SVG sprite element in the DOM |
+| `svgDomId` | `string` | `undefined` | ID attribute for the root SVG sprite element in the DOM |
 | `inject` | `'body-last' \| 'body-first'` | `undefined` | Controls where the sprite is injected in the HTML. `body-first` injects at start of body, `body-last` at the end |
 | `svgoConfig` | `object` | See SVGO section | Configuration for SVGO optimization. Override default settings for SVG optimization |
 | `fileName` | `string` | `undefined` | If provided, saves the sprite to a file instead of injecting it. Example: `sprite.svg` |

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const svgSpritePlugin = (options: SvgSpritePluginOptions): Plugin => {
   const {
     iconDirs,
     symbolId = '[dir]-[name]',
-    svgDomId = 'svg-sprite',
+    svgDomId,
     svgoConfig = {
       plugins: [
         {
@@ -173,10 +173,10 @@ const svgSpritePlugin = (options: SvgSpritePluginOptions): Plugin => {
 
     if (svgSymbols.length > 0) {
       const defsContent = collectedDefs ? `<defs>${collectedDefs}</defs>` : '';
-      spriteContent = `<svg xmlns="http://www.w3.org/2000/svg" style="${style}" id="${svgDomId}">${defsContent}${svgSymbols}</svg>`;
+      spriteContent = `<svg xmlns="http://www.w3.org/2000/svg" style="${style}"${svgDomId ? ` id="${svgDomId}"` : ''}>${defsContent}${svgSymbols}</svg>`;
     } else {
       log.warn('No SVG symbols were generated.');
-      spriteContent = `<svg xmlns="http://www.w3.org/2000/svg" style="${style}" id="${svgDomId}"></svg>`;
+      spriteContent = `<svg xmlns="http://www.w3.org/2000/svg" style="${style}"${svgDomId ? ` id="${svgDomId}"` : ''}></svg>`;
     }
 
     return spriteContent;


### PR DESCRIPTION
When injecting the SVG into HTML, you typically don't need the root SVG ID attribute.
If you omit the `svgDomId` option, the default `svg-sprite` is set, and if you pass an empty string, it will output an empty ID attribute.

This change doesn't output a root SVG ID attribute at all if you don't set it in the `svgDomId` option.

Perhaps I'm not aware of a case where you need a ID attribute in the root SVG...